### PR TITLE
Changed AuthenticationType check and added Load/Save methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ static SharePointContextProvider()
     }
     else
     {
-        if(HttpContext.Current.User.Identity.AuthenticationType == "Federation") {
+        if(HttpContext.Current.User.Identity.GetType() == typeof(ClaimsIdentity)) {
             SharePointContextProvider.current = new SharePointHighTrustSamlContextProvider();
         } else {
             SharePointContextProvider.current = new SharePointHighTrustContextProvider();

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ static SharePointContextProvider()
     }
     else
     {
-        if(HttpContext.Current.User.Identity.GetType() == typeof(ClaimsIdentity)) {
+        if (HttpContext.Current.User.Identity.GetType() == typeof(ClaimsIdentity)) {
             SharePointContextProvider.current = new SharePointHighTrustSamlContextProvider();
         } else {
             SharePointContextProvider.current = new SharePointHighTrustContextProvider();

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ static SharePointContextProvider()
     }
     else
     {
-        if(HttpContext.Current.User.Identity.GetType() == typeof(ClaimsIdentity)) {
+        if(HttpContext.Current.User.Identity.AuthenticationType == "Federation") {
             SharePointContextProvider.current = new SharePointHighTrustSamlContextProvider();
         } else {
             SharePointContextProvider.current = new SharePointHighTrustContextProvider();

--- a/SharePointContextSaml.cs
+++ b/SharePointContextSaml.cs
@@ -326,7 +326,7 @@ namespace Replace.This.With.Your.Custom.Namespace
             return id;
         }
 
-        
+
         /// <summary>
         /// NOT IMPLEMENTED
         /// </summary>
@@ -518,11 +518,11 @@ namespace Replace.This.With.Your.Custom.Namespace
     /// </summary>
     public class SharePointHighTrustSamlContextProvider : SharePointHighTrustContextProvider
     {
-
+        private const string SPContextKey = "SPContext";
         protected override SharePointContext CreateSharePointContext(Uri spHostUrl, Uri spAppWebUrl, string spLanguage, string spClientTag, string spProductNumber, HttpRequestBase httpRequest)
         {
             ClaimsIdentity logonUserIdentity = HttpContext.Current.User.Identity as ClaimsIdentity;
-            if (logonUserIdentity == null || !logonUserIdentity.IsAuthenticated )
+            if (logonUserIdentity == null || !logonUserIdentity.IsAuthenticated)
             {
                 return null;
             }
@@ -552,9 +552,9 @@ namespace Replace.This.With.Your.Custom.Namespace
             return httpContext.Session[SPContextKey] as SharePointHighTrustSamlContext;
         }
 
-        protected override SharePointContext SaveSharePointContext(HttpContextBase httpContext)
+        protected override void SaveSharePointContext(SharePointContext spContext, HttpContextBase httpContext)
         {
-            return httpContext.Session[SPContextKey] as SharePointHighTrustSamlContext;
+            httpContext.Session[SPContextKey] = spContext as SharePointHighTrustSamlContext;
         }
     }
 

--- a/SharePointContextSaml.cs
+++ b/SharePointContextSaml.cs
@@ -546,6 +546,16 @@ namespace Replace.This.With.Your.Custom.Namespace
 
             return false;
         }
+
+        protected override SharePointContext LoadSharePointContext(HttpContextBase httpContext)
+        {
+            return httpContext.Session[SPContextKey] as SharePointHighTrustSamlContext;
+        }
+
+        protected override SharePointContext SaveSharePointContext(HttpContextBase httpContext)
+        {
+            return httpContext.Session[SPContextKey] as SharePointHighTrustSamlContext;
+        }
     }
 
     #endregion HighTrust

--- a/SharePointContextSaml.cs
+++ b/SharePointContextSaml.cs
@@ -546,16 +546,6 @@ namespace Replace.This.With.Your.Custom.Namespace
 
             return false;
         }
-
-        protected override SharePointContext LoadSharePointContext(HttpContextBase httpContext)
-        {
-            return httpContext.Session[SPContextKey] as SharePointHighTrustSamlContext;
-        }
-
-        protected override SharePointContext SaveSharePointContext(HttpContextBase httpContext)
-        {
-            return httpContext.Session[SPContextKey] as SharePointHighTrustSamlContext;
-        }
     }
 
     #endregion HighTrust


### PR DESCRIPTION
I was writing a prov hosted app, based on OWIN, but the code didn't work, as the AuthenticationType is Cookies instead of Federation, due some technical reasons. I fixed this in your code example and I added the Load and Save functions: no usless redirects to SharePoint on each Action that has been marked with the SharePointContextFilterAttribute. Can you please accept this one? I can then update my new blogpost to your repository, instead of pointing to my fork
